### PR TITLE
Allow retrying dialog handling and always clear state

### DIFF
--- a/src/tools/dialogs.ts
+++ b/src/tools/dialogs.ts
@@ -36,11 +36,19 @@ const handleDialog: ToolFactory = captureSnapshot => defineTool({
     if (!dialogState)
       throw new Error('No dialog visible');
 
-    if (params.accept)
-      await dialogState.dialog.accept(params.promptText);
-    else
-      await dialogState.dialog.dismiss();
+    let attempt = 0;
+    while (attempt < 3) {
+      try {
+        if (params.accept) await dialogState.dialog.accept(params.promptText);
+        else await dialogState.dialog.dismiss();
+        break;
+      } catch (error) {
+        console.error(error);
+        attempt++;
+      }
+    }
 
+    // Always clear the dialog state, even if the dialog is not handled.
     context.clearModalState(dialogState);
 
     const code = [


### PR DESCRIPTION
- Added a retry mechanism to the dialog handling process, allowing up to three attempts to accept or dismiss the dialog, improving robustness against transient errors.
- Ensured that the dialog state is always cleared after handling, regardless of success or failure.